### PR TITLE
Rewrite + Backend changes + New default branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 rust
-docs
+html
 gcloud_keyfile.json
+cargo.log


### PR DESCRIPTION
Total rewrite of the script. No longer have any platform-related code in the script. See --help for options (or, just, read the script).

This corresponds with a back-end change which went into effect today, and absent any major issues should remain permanently.

Previously:

* Docs were stored in a cloud bucket, necessitating the use of a load-balancing front-end.
* Docs were distributed via Google CDN. Later, Cloudflare CDN was added on top.
* Since Google's CDN was essentially built into the previous design, both CDNs were left in place (with Cloudflare serving end-users)

Now:

* Docs are stored and served on a VM instance.
* Only Cloudflare CDN is used for front-end access.

The end result is significantly cheaper. The back-end is less resilient to failure, now relying on a single GCP zone for availability. However deployment is relatively simple, so in the event of a catastrophic GCP failure, it should be quick to spin up a new instance.

In the future, more targets can be added with very low cost-scaling.

Platform-specific (GCP) deployment stuff may be open sourced after I clean some things up.

This PR signifies the end of the old back-end. It can still be accessed (for now) at old.stdrs.dev, however updates have been disabled and the old site will go away permanently at some point in the near future (maybe a week, maybe a month). Once the old site is permanently gone, this PR will be closed (not merged with master) and the default branch changed to main (where this PR comes from).